### PR TITLE
Testcontainers 연동 예시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,13 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // https://docs.spring.io/spring-boot/appendix/dependency-versions/coordinates.html
+    // https://testcontainers.com/guides/testing-spring-boot-rest-api-using-testcontainers/
+    // https://java.testcontainers.org/test_framework_integration/junit_5/
+    testImplementation 'org.testcontainers:junit-jupiter'
+    // https://testcontainers.com/modules/postgresql/
+    testImplementation 'org.testcontainers:postgresql'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     // https://testcontainers.com/modules/postgresql/
     testImplementation 'org.testcontainers:postgresql'
+
+    // https://testcontainers.com/modules/localstack/
+    testImplementation 'org.testcontainers:localstack'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sprint/mission/discodeit/config/S3Config.java
+++ b/src/main/java/com/sprint/mission/discodeit/config/S3Config.java
@@ -1,0 +1,45 @@
+package com.sprint.mission.discodeit.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@ConditionalOnProperty(name = "discodeit.storage.type", havingValue = "s3")
+public class S3Config {
+
+    @Value("${discodeit.storage.s3.access-key}")
+    private String accessKey;
+
+    @Value("${discodeit.storage.s3.secret-key}")
+    private String secretKey;
+
+    @Value("${discodeit.storage.s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+            .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+            .build();
+    }
+}

--- a/src/main/java/com/sprint/mission/discodeit/storage/S3BinaryContentStorage.java
+++ b/src/main/java/com/sprint/mission/discodeit/storage/S3BinaryContentStorage.java
@@ -4,6 +4,8 @@ import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentDto;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.UUID;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -24,33 +26,21 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 @ConditionalOnProperty(name = "discodeit.storage.type", havingValue = "s3")
 public class S3BinaryContentStorage implements BinaryContentStorage {
 
-    private final String accessKey;
-    private final String secretKey;
-    private final String region;
-    private final String bucket;
-    private final int presignedUrlExpiration;
+    @Value("${discodeit.storage.s3.bucket}")
+    private String bucket;
 
-    public S3BinaryContentStorage(
-            @Value("${discodeit.storage.s3.access-key}") String accessKey,
-            @Value("${discodeit.storage.s3.secret-key}") String secretKey,
-            @Value("${discodeit.storage.s3.region}") String region,
-            @Value("${discodeit.storage.s3.bucket}") String bucket,
-            @Value("${discodeit.storage.s3.presigned-url-expiration}") int presignedUrlExpiration
-    ) {
-        this.accessKey = accessKey;
-        this.secretKey = secretKey;
-        this.region = region;
-        this.bucket = bucket;
-        this.presignedUrlExpiration = presignedUrlExpiration;
-    }
+    @Value("${discodeit.storage.s3.presigned-url-expiration}")
+    private int presignedUrlExpiration;
 
+    private final S3Client s3;
+    private final S3Presigner presigner;
 
     @Override
     public UUID put(UUID binaryContentId, byte[] bytes) {
-        S3Client s3 = getS3Client();
         String key = toKey(binaryContentId);
 
         PutObjectRequest putRequest = PutObjectRequest.builder()
@@ -63,7 +53,6 @@ public class S3BinaryContentStorage implements BinaryContentStorage {
     }
 
     public InputStream get(UUID binaryContentId) {
-        S3Client s3 = getS3Client();
         String key = toKey(binaryContentId);
 
         GetObjectRequest getRequest = GetObjectRequest.builder()
@@ -76,7 +65,6 @@ public class S3BinaryContentStorage implements BinaryContentStorage {
 
     @Override
     public UUID delete(UUID binaryContentId) {
-        S3Client s3 = getS3Client();
         String key = toKey(binaryContentId);
 
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
@@ -100,23 +88,7 @@ public class S3BinaryContentStorage implements BinaryContentStorage {
                 .build();
     }
 
-    public S3Client getS3Client() {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-
-        return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                .build();
-    }
-
     private String generatePresignedUrl(String key, String contentType) {
-        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
-
-        try (S3Presigner presigner = S3Presigner.builder()
-                .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                .build()) {
-
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucket)
                     .key(key)
@@ -130,7 +102,6 @@ public class S3BinaryContentStorage implements BinaryContentStorage {
                             .build());
 
             return presignedRequest.url().toString();
-        }
     }
 
     private String toKey(UUID id) {

--- a/src/main/java/com/sprint/mission/discodeit/storage/S3BinaryContentStorage.java
+++ b/src/main/java/com/sprint/mission/discodeit/storage/S3BinaryContentStorage.java
@@ -100,7 +100,7 @@ public class S3BinaryContentStorage implements BinaryContentStorage {
                 .build();
     }
 
-    private S3Client getS3Client() {
+    public S3Client getS3Client() {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Client.builder()

--- a/src/test/java/com/sprint/mission/discodeit/AbstractContainerBaseTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/AbstractContainerBaseTest.java
@@ -1,0 +1,39 @@
+package com.sprint.mission.discodeit;
+
+import com.sprint.mission.discodeit.config.AppConfig;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+@Import(AppConfig.class)
+@ActiveProfiles("container")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class AbstractContainerBaseTest {
+
+    private static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>(DockerImageName.parse("postgres:15"))
+        .withDatabaseName("testdb")
+        .withUsername("testuser")
+        .withPassword("testpass")
+//        .withInitScript("schema.sql"); // resources 폴더 기준이어서 사용하기 어려움
+        .withCopyFileToContainer(
+            MountableFile.forHostPath("schema.sql"),
+            "/docker-entrypoint-initdb.d/schema.sql"
+        );
+
+    static {
+        POSTGRES_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.driver-class-name", POSTGRES_CONTAINER::getDriverClassName);
+        registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
+    }
+}

--- a/src/test/java/com/sprint/mission/discodeit/AbstractContainerBaseTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/AbstractContainerBaseTest.java
@@ -1,18 +1,29 @@
 package com.sprint.mission.discodeit;
 
 import com.sprint.mission.discodeit.config.AppConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Import(AppConfig.class)
 @ActiveProfiles("container")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration(classes = AbstractContainerBaseTest.TestContainersConfiguration.class)
 public abstract class AbstractContainerBaseTest {
 
     private static final PostgreSQLContainer<?> POSTGRES_CONTAINER = new PostgreSQLContainer<>(DockerImageName.parse("postgres:15"))
@@ -25,8 +36,14 @@ public abstract class AbstractContainerBaseTest {
             "/docker-entrypoint-initdb.d/schema.sql"
         );
 
+    private static final LocalStackContainer LOCAL_STACK_CONTAINER = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.5.0"))
+        .withServices(
+            LocalStackContainer.Service.S3
+        );
+
     static {
         POSTGRES_CONTAINER.start();
+        LOCAL_STACK_CONTAINER.start();
     }
 
     @DynamicPropertySource
@@ -35,5 +52,40 @@ public abstract class AbstractContainerBaseTest {
         registry.add("spring.datasource.driver-class-name", POSTGRES_CONTAINER::getDriverClassName);
         registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
         registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
+
+        registry.add("discodeit.storage.s3.access-key", LOCAL_STACK_CONTAINER::getAccessKey);
+        registry.add("discodeit.storage.s3.secret-key", LOCAL_STACK_CONTAINER::getSecretKey);
+        registry.add("discodeit.storage.s3.region", LOCAL_STACK_CONTAINER::getRegion);
+    }
+
+    @TestConfiguration
+    static class TestContainersConfiguration {
+
+        @Bean
+        public S3Client s3Client() {
+            return S3Client.builder()
+                .endpointOverride(LOCAL_STACK_CONTAINER.getEndpointOverride(LocalStackContainer.Service.S3))
+                .region(Region.of(LOCAL_STACK_CONTAINER.getRegion()))
+                .credentialsProvider(
+                    StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                            LOCAL_STACK_CONTAINER.getAccessKey(),
+                            LOCAL_STACK_CONTAINER.getSecretKey()
+                        )
+                    )
+                )
+                .build();
+        }
+
+        /**
+         * 초기 버킷 생성
+         */
+        @Bean
+        public CommandLineRunner createInitialBucket(
+            S3Client s3Client,
+            @Value("${discodeit.storage.s3.bucket}") String bucket
+        ) {
+            return args -> s3Client.createBucket(builder -> builder.bucket(bucket));
+        }
     }
 }

--- a/src/test/java/com/sprint/mission/discodeit/DiscodeitApplicationTests.java
+++ b/src/test/java/com/sprint/mission/discodeit/DiscodeitApplicationTests.java
@@ -5,8 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
-class DiscodeitApplicationTests {
+class DiscodeitApplicationTests extends AbstractContainerBaseTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/sprint/mission/discodeit/integration/AuthApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/AuthApiIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.auth.LoginRequest;
 import com.sprint.mission.discodeit.dto.user.UserCreateRequest;
 import com.sprint.mission.discodeit.service.UserService;
@@ -22,9 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class AuthApiIntegrationTest {
+class AuthApiIntegrationTest extends AbstractContainerBaseTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/sprint/mission/discodeit/integration/BinaryContentApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/BinaryContentApiIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentCreateRequest;
 import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentDto;
 import com.sprint.mission.discodeit.dto.channel.PublicChannelCreateRequest;
@@ -35,9 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class BinaryContentApiIntegrationTest {
+class BinaryContentApiIntegrationTest extends AbstractContainerBaseTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/sprint/mission/discodeit/integration/ChannelApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/ChannelApiIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.channel.ChannelDto;
 import com.sprint.mission.discodeit.dto.channel.ChannelUpdateRequest;
 import com.sprint.mission.discodeit.dto.channel.PrivateChannelCreateRequest;
@@ -34,9 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class ChannelApiIntegrationTest {
+class ChannelApiIntegrationTest extends AbstractContainerBaseTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/sprint/mission/discodeit/integration/MessageApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/MessageApiIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.channel.ChannelDto;
 import com.sprint.mission.discodeit.dto.channel.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.message.MessageCreateRequest;
@@ -36,9 +37,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class MessageApiIntegrationTest {
+class MessageApiIntegrationTest extends AbstractContainerBaseTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/sprint/mission/discodeit/integration/ReadStatusApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/ReadStatusApiIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.channel.ChannelDto;
 import com.sprint.mission.discodeit.dto.channel.PublicChannelCreateRequest;
 import com.sprint.mission.discodeit.dto.readStatus.ReadStatusCreateRequest;
@@ -35,9 +36,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class ReadStatusApiIntegrationTest {
+class ReadStatusApiIntegrationTest extends AbstractContainerBaseTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/sprint/mission/discodeit/integration/UserApiIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/integration/UserApiIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.user.UserCreateRequest;
 import com.sprint.mission.discodeit.dto.user.UserDto;
 import com.sprint.mission.discodeit.dto.user.UserUpdateRequest;
@@ -31,9 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
 @Transactional
-class UserApiIntegrationTest {
+class UserApiIntegrationTest extends AbstractContainerBaseTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/sprint/mission/discodeit/repository/ChannelRepositoryTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/repository/ChannelRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.config.AppConfig;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
@@ -18,9 +19,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@ActiveProfiles("test")
-@Import(AppConfig.class)
-public class ChannelRepositoryTest {
+public class ChannelRepositoryTest extends AbstractContainerBaseTest {
 
     @Autowired
     private ChannelRepository channelRepository;

--- a/src/test/java/com/sprint/mission/discodeit/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/repository/MessageRepositoryTest.java
@@ -9,6 +9,8 @@ import com.sprint.mission.discodeit.entity.ChannelType;
 import com.sprint.mission.discodeit.entity.Message;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
+
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -54,7 +56,7 @@ public class MessageRepositoryTest extends AbstractContainerBaseTest {
         userRepository.deleteAll();
 
         user = new User("user", "user.gmail.com", "password", null);
-        UserStatus userStatus = new UserStatus(user, Instant.MIN);
+        UserStatus userStatus = new UserStatus(user, Instant.now()); // Instant.MIN은 Postgresql의 timestampz에서 호환 안됨
         channel = new Channel(ChannelType.PUBLIC, "Public Channel", "This is a public channel.");
         message1 = new Message(user, channel, "1", null);
         message2 = new Message(user, channel, "2", null);
@@ -65,10 +67,10 @@ public class MessageRepositoryTest extends AbstractContainerBaseTest {
         messageRepository.save(message2);
 
         jdbcTemplate.update("UPDATE  messages SET created_at = ? WHERE id = ?",
-                Instant.parse("2025-05-20T00:00:00Z"), message1.getId());
+            Timestamp.from(Instant.parse("2025-05-20T00:00:00Z")), message1.getId());
 
         jdbcTemplate.update("UPDATE  messages SET created_at = ? WHERE id = ?",
-                Instant.parse("2025-05-21T00:00:00Z"), message2.getId());
+            Timestamp.from(Instant.parse("2025-05-21T00:00:00Z")), message2.getId());
 
         entityManager.flush();
         entityManager.clear();

--- a/src/test/java/com/sprint/mission/discodeit/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/repository/MessageRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.config.AppConfig;
 import com.sprint.mission.discodeit.entity.Channel;
 import com.sprint.mission.discodeit.entity.ChannelType;
@@ -24,9 +25,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@ActiveProfiles("test")
-@Import(AppConfig.class)
-public class MessageRepositoryTest {
+public class MessageRepositoryTest extends AbstractContainerBaseTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;

--- a/src/test/java/com/sprint/mission/discodeit/repository/UserRepositoryTest.java
+++ b/src/test/java/com/sprint/mission/discodeit/repository/UserRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sprint.mission.discodeit.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.config.AppConfig;
 import com.sprint.mission.discodeit.entity.User;
 import com.sprint.mission.discodeit.entity.UserStatus;
@@ -17,9 +18,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@ActiveProfiles("test")
-@Import(AppConfig.class)
-public class UserRepositoryTest {
+public class UserRepositoryTest extends AbstractContainerBaseTest {
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/com/sprint/mission/discodeit/storage/s3/AWSS3Test.java
+++ b/src/test/java/com/sprint/mission/discodeit/storage/s3/AWSS3Test.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.willReturn;
 
+import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentDto;
 import com.sprint.mission.discodeit.storage.S3BinaryContentStorage;
 import java.io.FileInputStream;
@@ -17,10 +19,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -36,8 +40,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 @SpringBootTest(properties = {
         "discodeit.storage.type=s3"
 })
-@ActiveProfiles("test")
-public class AWSS3Test {
+public class AWSS3Test extends AbstractContainerBaseTest {
 
     @Value("${discodeit.storage.s3.access-key}")
     private String accessKey;
@@ -54,11 +57,15 @@ public class AWSS3Test {
     @Value("${discodeit.storage.s3.presigned-url-expiration}")
     private int expiration;
 
+    @MockitoSpyBean
     private S3BinaryContentStorage storage;
+
+    @Autowired
+    private S3Client s3Client;
 
     @BeforeEach
     void setup() throws Exception {
-        storage = new S3BinaryContentStorage(accessKey, secretKey, region, bucket, expiration);
+        willReturn(s3Client).given(storage).getS3Client();
     }
 
     @Test

--- a/src/test/java/com/sprint/mission/discodeit/storage/s3/AWSS3Test.java
+++ b/src/test/java/com/sprint/mission/discodeit/storage/s3/AWSS3Test.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.BDDMockito.willReturn;
 
 import com.sprint.mission.discodeit.AbstractContainerBaseTest;
 import com.sprint.mission.discodeit.dto.binaryContent.BinaryContentDto;
@@ -24,7 +23,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -57,16 +55,8 @@ public class AWSS3Test extends AbstractContainerBaseTest {
     @Value("${discodeit.storage.s3.presigned-url-expiration}")
     private int expiration;
 
-    @MockitoSpyBean
-    private S3BinaryContentStorage storage;
-
     @Autowired
-    private S3Client s3Client;
-
-    @BeforeEach
-    void setup() throws Exception {
-        willReturn(s3Client).given(storage).getS3Client();
-    }
+    private S3BinaryContentStorage storage;
 
     @Test
     void testPutAndGet() throws IOException {

--- a/src/test/java/com/sprint/mission/discodeit/storage/s3/AWSS3Test.java
+++ b/src/test/java/com/sprint/mission/discodeit/storage/s3/AWSS3Test.java
@@ -40,21 +40,6 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 })
 public class AWSS3Test extends AbstractContainerBaseTest {
 
-    @Value("${discodeit.storage.s3.access-key}")
-    private String accessKey;
-
-    @Value("${discodeit.storage.s3.secret-key}")
-    private String secretKey;
-
-    @Value("${discodeit.storage.s3.region}")
-    private String region;
-
-    @Value("${discodeit.storage.s3.bucket}")
-    private String bucket;
-
-    @Value("${discodeit.storage.s3.presigned-url-expiration}")
-    private int expiration;
-
     @Autowired
     private S3BinaryContentStorage storage;
 

--- a/src/test/resources/application-container.yaml
+++ b/src/test/resources/application-container.yaml
@@ -1,0 +1,29 @@
+spring:
+#  datasource:
+#    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+#    driver-class-name: org.h2.Driver
+#    username: sa
+#    password: password
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.springframework.test: info
+
+discodeit:
+  storage:
+    type: s3
+    s3:
+#      access-key: ${AWS_S3_ACCESS_KEY}
+#      secret-key: ${AWS_S3_SECRET_KEY}
+#      region: ${AWS_S3_REGION:ap-northeast-2}
+      bucket: test-bucket
+      presigned-url-expiration: ${PRESIGNED_URL_EXPIRATION:600}

--- a/src/test/resources/application-container.yaml
+++ b/src/test/resources/application-container.yaml
@@ -27,3 +27,9 @@ discodeit:
 #      region: ${AWS_S3_REGION:ap-northeast-2}
       bucket: test-bucket
       presigned-url-expiration: ${PRESIGNED_URL_EXPIRATION:600}
+
+---
+
+spring:
+  main:
+    allow-bean-definition-overriding: true


### PR DESCRIPTION
### 필요 조건

1. 테스트 환경에서 Docker Demon 활성화 필요
    - 로컬 PC에서는 Docker Desktop 켜져 있어야 함

### 구현 설명

1. Testcontainers가 필요한 테스트 클래스에 AbstractContainerBaseTest를 extends하여 간단하게 구성
    - 테스트를 한 번에 돌리는 경우 컨테이너 한 번만 띄워서 동일한 환경 재사용으로 컨테이너 띄우는 시간 감소
    - 동일한 어노테이션 및 설정은 한 번만 선언하여 구현 편의성 향상

### 개선 사항

1. H2 인메모리 DB에서 PostgreSQL로 DB 테스트
    - 운영 환경과 동일한 PostgreSQL로 테스트 가능
2. 실제 S3 연동 없이 최대한 비슷한 환경 구현
    - S3 업로드 비용 X
    - 테스트 시 실제 Key 불필요

### TO DO

1. Active Profile - container 및 test 공존 여부 고려 필요
    - 현재는 설명을 위해 기존 test는 그대로 두고 container만 추가한 형태.
    - 추후에는 test로 통일하거나 조금 더 명확한 profile 명으로 분리 필요
2. 바이너리 컨텐츠 다운로드 API 통합 테스트 수정 필요
    - binaryContentStorage.download() 메서드의 구현 호환 문제로 인해 실패